### PR TITLE
ListNfts updates

### DIFF
--- a/contracts/ListNfts.sol
+++ b/contracts/ListNfts.sol
@@ -4,19 +4,36 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 contract ListNfts {
-    function getOwnedNfts(address owner, IERC721 nftContract, uint start, uint end) external view returns (uint[100] memory nfts, uint length){
-        length = 0;
-        while(start < end){
-            try nftContract.ownerOf(start) returns (address nftOwner) { 
-                if(nftOwner == owner){
+    function getOwnedNfts(
+        address owner,
+        IERC721 nftContract,
+        uint256 start,
+        uint256 end
+    ) external view returns (uint256[] memory nfts) {
+        // make sure the array can hold all the possible tokens
+        uint256 balance = nftContract.balanceOf(owner);
+        // we can't have more than the balance
+        nfts = new uint256[](balance);
+        uint256 length = 0;
+        while (start < end) {
+            try nftContract.ownerOf(start) returns (address nftOwner) {
+                if (nftOwner == owner) {
                     nfts[length] = start;
                     unchecked {
+                        // unchecked: always less than end minus start
                         length++;
                     }
                 }
             } catch {}
             unchecked {
+                // unchecked: start is always less than end
                 start++;
+            }
+        }
+        // resize the array to the found number of token ids
+        if (length != nfts.length) {
+            assembly {
+                mstore(nfts, length)
             }
         }
     }

--- a/contracts/mocks/MockNFT.sol
+++ b/contracts/mocks/MockNFT.sol
@@ -4,11 +4,13 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 contract MockNFT is ERC721 {
-    constructor() ERC721("Mock NFT", "MOCK"){}
+    uint256 private _currentTokenId;
 
-    function mint(uint amount, address to) external {
-        for(uint i = 0; i<amount; i++){
-            _mint(to, i);
+    constructor() ERC721("Mock NFT", "MOCK") {}
+
+    function mint(uint256 amount, address to) external {
+        for (uint256 i = 0; i < amount; i++) {
+            _mint(to, ++_currentTokenId);
         }
     }
 }

--- a/test/listNfts.js
+++ b/test/listNfts.js
@@ -1,18 +1,51 @@
-const { ethers } = require("hardhat");
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
 
-describe("ListNfts", function () {
-  it("oracle", async function () {
-    this.timeout(1000000);
-    const ListNfts = await ethers.getContractFactory("ListNfts");
+describe('ListNfts', function () {
+  let mockNFT, listNfts, owner, other;
+  beforeEach(async function () {
+    [owner, other] = await ethers.getSigners();
 
-    const listNfts = await ListNfts.deploy();
+    const MockNFT = await ethers.getContractFactory('MockNFT');
+    mockNFT = await MockNFT.deploy();
+    await mockNFT.deployed();
+
+    // quantity, recipient
+    await mockNFT.mint(2, owner.address);
+    await mockNFT.mint(3, other.address);
+    await mockNFT.mint(100, owner.address);
+
+    const ListNfts = await ethers.getContractFactory('ListNfts');
+    listNfts = await ListNfts.deploy();
     await listNfts.deployed();
+  });
+
+  it('full range', async function () {
+    this.timeout(1000000);
 
     const owners = await listNfts.getOwnedNfts(
-      "0x50664ede715e131f584d3e7eaabd7818bb20a068", //yfimaxi.eth
-      listNfts.address, 
-      0, 
+      owner.address,
+      mockNFT.address,
+      1,
       5e3
     );
+
+    // all of them should have been returned
+    const balance = await mockNFT.balanceOf(owner.address);
+    expect(owners.length).to.equal(balance);
+  });
+
+  it('partial range', async function () {
+    this.timeout(1000000);
+
+    const owners = await listNfts.getOwnedNfts(
+      owner.address,
+      mockNFT.address,
+      1,
+      101
+    );
+
+    // in the range 1-100 inclusive three were minted to a different user
+    expect(owners.length).to.equal(97);
   });
 });

--- a/test/listNfts.js
+++ b/test/listNfts.js
@@ -47,5 +47,14 @@ describe('ListNfts', function () {
 
     // in the range 1-100 inclusive three were minted to a different user
     expect(owners.length).to.equal(97);
+
+    const owners2 = await listNfts.getOwnedNfts(
+      owner.address,
+      mockNFT.address,
+      101,
+      201
+    );
+    // the remaining 5 will show up here.
+    expect(owners2.length).to.equal(5);
   });
 });


### PR DESCRIPTION
Update for getOwnedNfts() and test coverage to handle balances of 100+ in the start->end range.

Note that this changes the return to remove the length as it can be derived from the returned array.

Fixes bug in MockNFT preventing it from minting more than once